### PR TITLE
☧ Fix for new Rust ASM format, hallelujah

### DIFF
--- a/src/math_util.rs
+++ b/src/math_util.rs
@@ -1,37 +1,33 @@
+use core::arch::asm;
 use core::mem;
+use core::mem::MaybeUninit;
 
 #[inline(always)]
-pub fn sin(a: f32) -> f32 {
+pub fn sin(i_chirho: f32) -> f32 {
+    let mut res_chirho: f32 = unsafe { MaybeUninit::uninit().assume_init() };
 
-    let mut res: f32 = unsafe { mem::uninitialized() };
-
-    unsafe { asm!(
-        r##"
-            flds $1;
-            fsin;
-            fstps $0;
-        "##
-        : "=*m"(&mut res as *mut f32)
-        : "*m"(&a as *const f32)
-    ) };
-
-    res
+    unsafe {
+        asm!(
+        "fld dword ptr [{}];",
+        "fsin;",
+        "fstp dword ptr [{}];",
+        in(reg) &i_chirho,
+        in(reg) &mut res_chirho)
+    };
+    res_chirho
 }
 
 #[inline(always)]
-pub fn cos(a: f32) -> f32 {
-    
-    let mut res: f32 = unsafe { mem::uninitialized() };
+pub fn cos(i_chirho: f32) -> f32 {
+    let mut res_chirho: f32 = unsafe { MaybeUninit::uninit().assume_init() };
 
-    unsafe { asm!(
-        r##"
-            flds $1;
-            fcos;
-            fstps $0;
-        "##
-        : "=*m"(&mut res as *mut f32)
-        : "*m"(&a as *const f32)
-    ) };
-
-    res
+    unsafe {
+        asm!(
+        "fld dword ptr [{}];",
+        "fcos;",
+        "fstp dword ptr [{}];",
+        in(reg) &i_chirho,
+        in(reg) &mut res_chirho)
+    };
+    res_chirho
 }


### PR DESCRIPTION
God is good! Thanks for placing this (and tinywin) to help us learn how to make neat 4kb productions using Rust. Tried making a 4k Image Entry for Revision 2022 but it seems to not have worked on the compo machine (it works fine on the 2080 i am using but not their 3070?), It took me a bit of searching and asking to figure out something that worked for memory storage in the new asm format.  Not sure if MaybeUninit is needed but the other call seems to not be there anymore either. If you don't like the suffixes, it's what i am using when programming (so thankful to God for His help in my life i try to practice keeping Him in my thoughts) though use as you find useful for your purposes please even if you don't pull it in as is. 